### PR TITLE
Add CPU usage per host alerting v2 rule type example

### DIFF
--- a/x-pack/examples/alerting_example/server/plugin.ts
+++ b/x-pack/examples/alerting_example/server/plugin.ts
@@ -16,6 +16,7 @@ import { ALERTING_FEATURE_ID } from '@kbn/alerting-plugin/common';
 import { ruleType as alwaysFiringRule } from './rule_types/always_firing';
 import { ruleType as peopleInSpaceRule } from './rule_types/astros';
 import { ruleType as patternRule } from './rule_types/pattern';
+import { ruleType as cpuUsagePerHostRule } from './rule_types/cpu_usage_per_host';
 // can't import static code from another plugin to support examples functional test
 const INDEX_THRESHOLD_ID = '.index-threshold';
 import { ALERTING_EXAMPLE_APP_ID } from '../common/constants';
@@ -31,6 +32,7 @@ export class AlertingExamplePlugin implements Plugin<void, void, AlertingExample
     alerting.registerType(alwaysFiringRule);
     alerting.registerType(peopleInSpaceRule);
     alerting.registerType(patternRule);
+    alerting.registerType(cpuUsagePerHostRule);
 
     features.registerKibanaFeature({
       id: ALERTING_EXAMPLE_APP_ID,
@@ -55,6 +57,10 @@ export class AlertingExamplePlugin implements Plugin<void, void, AlertingExample
           ruleTypeId: INDEX_THRESHOLD_ID,
           consumers: [ALERTING_EXAMPLE_APP_ID, ALERTING_FEATURE_ID],
         },
+        {
+          ruleTypeId: cpuUsagePerHostRule.id,
+          consumers: [ALERTING_EXAMPLE_APP_ID, ALERTING_FEATURE_ID],
+        },
       ],
       privileges: {
         all: {
@@ -73,6 +79,10 @@ export class AlertingExamplePlugin implements Plugin<void, void, AlertingExample
                   ruleTypeId: INDEX_THRESHOLD_ID,
                   consumers: [ALERTING_EXAMPLE_APP_ID, ALERTING_FEATURE_ID],
                 },
+                {
+                  ruleTypeId: cpuUsagePerHostRule.id,
+                  consumers: [ALERTING_EXAMPLE_APP_ID, ALERTING_FEATURE_ID],
+                },
               ],
             },
             alert: {
@@ -87,6 +97,10 @@ export class AlertingExamplePlugin implements Plugin<void, void, AlertingExample
                 },
                 {
                   ruleTypeId: INDEX_THRESHOLD_ID,
+                  consumers: [ALERTING_EXAMPLE_APP_ID, ALERTING_FEATURE_ID],
+                },
+                {
+                  ruleTypeId: cpuUsagePerHostRule.id,
                   consumers: [ALERTING_EXAMPLE_APP_ID, ALERTING_FEATURE_ID],
                 },
               ],
@@ -117,6 +131,10 @@ export class AlertingExamplePlugin implements Plugin<void, void, AlertingExample
                   ruleTypeId: INDEX_THRESHOLD_ID,
                   consumers: [ALERTING_EXAMPLE_APP_ID, ALERTING_FEATURE_ID],
                 },
+                {
+                  ruleTypeId: cpuUsagePerHostRule.id,
+                  consumers: [ALERTING_EXAMPLE_APP_ID, ALERTING_FEATURE_ID],
+                },
               ],
             },
             alert: {
@@ -131,6 +149,10 @@ export class AlertingExamplePlugin implements Plugin<void, void, AlertingExample
                 },
                 {
                   ruleTypeId: INDEX_THRESHOLD_ID,
+                  consumers: [ALERTING_EXAMPLE_APP_ID, ALERTING_FEATURE_ID],
+                },
+                {
+                  ruleTypeId: cpuUsagePerHostRule.id,
                   consumers: [ALERTING_EXAMPLE_APP_ID, ALERTING_FEATURE_ID],
                 },
               ],

--- a/x-pack/examples/alerting_example/server/rule_types/cpu_usage_per_host.ts
+++ b/x-pack/examples/alerting_example/server/rule_types/cpu_usage_per_host.ts
@@ -1,0 +1,221 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RuleType, RuleTypeParams, RuleTypeState } from '@kbn/alerting-plugin/server';
+import { DEFAULT_AAD_CONFIG, AlertsClientError } from '@kbn/alerting-plugin/server';
+import { schema } from '@kbn/config-schema';
+import type { DefaultAlert } from '@kbn/alerts-as-data-utils';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { ALERTING_EXAMPLE_APP_ID } from '../../common/constants';
+
+interface CpuUsageParams extends RuleTypeParams {
+  threshold: number;
+  warnThreshold?: number;
+  timeWindowMinutes: number;
+  indexPattern: string;
+  hostField: string;
+  cpuField: string;
+  filterQuery?: string;
+}
+
+interface CpuUsageState extends RuleTypeState {
+  lastCheckedAt?: string;
+}
+
+interface AlertState {
+  host: string;
+  cpuUsage: number;
+}
+
+type CpuActionGroupIds = 'cpu_critical' | 'cpu_warning';
+
+async function queryCpuUsagePerHost(
+  esClient: ElasticsearchClient,
+  params: CpuUsageParams
+): Promise<Array<{ host: string; cpuUsage: number }>> {
+  const { indexPattern, timeWindowMinutes, hostField, cpuField, filterQuery } = params;
+
+  const query: Record<string, unknown> = {
+    bool: {
+      filter: [
+        {
+          range: {
+            '@timestamp': {
+              gte: `now-${timeWindowMinutes}m`,
+              lte: 'now',
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  if (filterQuery) {
+    (query.bool as Record<string, unknown[]>).filter.push({
+      query_string: { query: filterQuery },
+    });
+  }
+
+  const response = await esClient.search({
+    index: indexPattern,
+    size: 0,
+    query,
+    aggs: {
+      hosts: {
+        terms: {
+          field: hostField,
+          size: 100,
+        },
+        aggs: {
+          avg_cpu: {
+            avg: {
+              field: cpuField,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const hostsAgg = response.aggregations?.hosts as
+    | { buckets: Array<{ key: string; avg_cpu: { value: number | null } }> }
+    | undefined;
+
+  if (!hostsAgg?.buckets) {
+    return [];
+  }
+
+  return hostsAgg.buckets
+    .filter((bucket) => bucket.avg_cpu.value != null)
+    .map((bucket) => ({
+      host: bucket.key,
+      cpuUsage: bucket.avg_cpu.value!,
+    }));
+}
+
+export const ruleType: RuleType<
+  CpuUsageParams,
+  never,
+  CpuUsageState,
+  AlertState,
+  never,
+  CpuActionGroupIds,
+  'recovered',
+  DefaultAlert
+> = {
+  id: 'example.cpu-usage-per-host',
+  name: 'CPU Usage Per Host',
+  actionGroups: [
+    { id: 'cpu_critical', name: 'CPU Critical' },
+    { id: 'cpu_warning', name: 'CPU Warning' },
+  ],
+  defaultActionGroupId: 'cpu_critical',
+  minimumLicenseRequired: 'basic',
+  isExportable: true,
+  recoveryActionGroup: {
+    id: 'recovered',
+    name: 'Recovered',
+  },
+  doesSetRecoveryContext: true,
+  actionVariables: {
+    context: [
+      { name: 'host', description: 'The hostname that triggered the alert' },
+      { name: 'cpuUsage', description: 'The average CPU usage percentage' },
+      { name: 'threshold', description: 'The configured threshold' },
+      {
+        name: 'reason',
+        description: 'A human-readable description of why the alert fired',
+      },
+    ],
+  },
+  async executor({ services, params, state }) {
+    const { alertsClient } = services;
+    if (!alertsClient) {
+      throw new AlertsClientError();
+    }
+
+    const esClient = services.scopedClusterClient.asCurrentUser;
+    const hostMetrics = await queryCpuUsagePerHost(esClient, params);
+
+    for (const { host, cpuUsage } of hostMetrics) {
+      if (cpuUsage >= params.threshold) {
+        alertsClient.report({
+          id: host,
+          actionGroup: 'cpu_critical',
+          state: { host, cpuUsage },
+          context: {
+            host,
+            cpuUsage: Math.round(cpuUsage * 1000) / 10,
+            threshold: params.threshold * 100,
+            reason: `CPU usage on ${host} is ${Math.round(cpuUsage * 1000) / 10}% (threshold: ${params.threshold * 100}%)`,
+          },
+        });
+      } else if (params.warnThreshold != null && cpuUsage >= params.warnThreshold) {
+        alertsClient.report({
+          id: host,
+          actionGroup: 'cpu_warning',
+          state: { host, cpuUsage },
+          context: {
+            host,
+            cpuUsage: Math.round(cpuUsage * 1000) / 10,
+            threshold: params.warnThreshold * 100,
+            reason: `CPU usage on ${host} is ${Math.round(cpuUsage * 1000) / 10}% (warning threshold: ${params.warnThreshold * 100}%)`,
+          },
+        });
+      }
+    }
+
+    return {
+      state: {
+        lastCheckedAt: new Date().toISOString(),
+      },
+    };
+  },
+  category: 'observability',
+  producer: ALERTING_EXAMPLE_APP_ID,
+  solution: 'stack',
+  alerts: DEFAULT_AAD_CONFIG,
+  validate: {
+    params: schema.object({
+      threshold: schema.number({
+        defaultValue: 0.9,
+        min: 0,
+        max: 1,
+        meta: { description: 'CPU usage threshold as a decimal (0.9 = 90%)' },
+      }),
+      warnThreshold: schema.maybe(
+        schema.number({
+          min: 0,
+          max: 1,
+          meta: { description: 'Warning threshold as a decimal (0.75 = 75%)' },
+        })
+      ),
+      timeWindowMinutes: schema.number({
+        defaultValue: 5,
+        min: 1,
+        meta: { description: 'Time window in minutes to aggregate CPU usage' },
+      }),
+      indexPattern: schema.string({
+        defaultValue: 'metrics-*',
+        meta: { description: 'Index pattern to query for CPU metrics' },
+      }),
+      hostField: schema.string({
+        defaultValue: 'host.name',
+        meta: { description: 'Field containing the host name' },
+      }),
+      cpuField: schema.string({
+        defaultValue: 'system.cpu.total.norm.pct',
+        meta: { description: 'Field containing the CPU usage value (0-1)' },
+      }),
+      filterQuery: schema.maybe(
+        schema.string({
+          meta: { description: 'Optional filter query to scope the data' },
+        })
+      ),
+    }),
+  },
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new example alerting v2 rule type (`example.cpu-usage-per-host`) that demonstrates how to create a rule to monitor CPU usage per host using the Kibana Alerting framework.

The rule type:
- Queries metrics indices for average CPU usage aggregated by host using an Elasticsearch terms + avg aggregation
- Supports both **critical** and **warning** thresholds (e.g., 90% and 75%)
- Uses configurable parameters: index pattern, host field, CPU metric field, and time window
- Supports optional filter queries for scoping to specific environments or clusters
- Reports per-host alerts with contextual information (host name, CPU %, threshold, human-readable reason)
- Includes a `recovered` action group for auto-resolving incidents in PagerDuty/Jira/ServiceNow
- Registered in the alerting example plugin with full feature privileges

### How to use via API

```bash
curl -X POST "https://my-kibana:5601/api/alerting/rule/cpu-per-host-01" \
  -H "kbn-xsrf: true" \
  -H "Content-Type: application/json" \
  -H "Authorization: ApiKey <your-api-key>" \
  -d '{
    "name": "CPU usage per host",
    "rule_type_id": "example.cpu-usage-per-host",
    "consumer": "alerts",
    "schedule": { "interval": "1m" },
    "params": {
      "threshold": 0.9,
      "warnThreshold": 0.75,
      "timeWindowMinutes": 5,
      "indexPattern": "metrics-*",
      "hostField": "host.name",
      "cpuField": "system.cpu.total.norm.pct"
    },
    "actions": []
  }'
```

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

This is an example plugin addition with no production impact. The rule type is only loaded when example plugins are enabled.

- [ ] No production risks — example plugin only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2ff4fea-ad0d-44d6-9b8e-b0f34c786f1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2ff4fea-ad0d-44d6-9b8e-b0f34c786f1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

